### PR TITLE
[Feat] Grafana Loki를 사용한 메인 서버 로깅 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
+    implementation 'com.github.maricn:logback-slack-appender:1.4.0'
     implementation 'org.springframework.retry:spring-retry'
     implementation 'org.springframework:spring-aspects'
     compileOnly 'org.projectlombok:lombok'

--- a/logging/alloy/alloy.yml
+++ b/logging/alloy/alloy.yml
@@ -1,0 +1,24 @@
+  logging {
+    level = "info"
+  }
+    
+    loki.write "default" {
+    endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+    }
+  }
+    
+    local.file_match "app_logs" {
+    path_targets = [
+    {
+    __path__ = "/var/log/app/application.log",
+    service  = "budongbudong",
+    env      = "dev",
+    },
+    ]
+  }
+    
+    loki.source.file "app_logs" {
+    targets    = local.file_match.app_logs.targets
+    forward_to = [loki.write.default.receiver]
+  }

--- a/logging/docker-compose.yml
+++ b/logging/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+
+services:
+  loki:
+    image: grafana/loki:2.9.4
+    container_name: loki
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: grafana/grafana:10.3.1
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - loki
+
+  alloy:
+    image: grafana/alloy:latest
+    container_name: alloy
+    volumes:
+      - ./logs:/var/log/app
+      - ./alloy/alloy.yml:/etc/alloy/alloy.yml
+    command: >
+      run /etc/alloy/alloy.yml

--- a/src/main/java/com/example/budongbudong/domain/property/controller/PropertyController.java
+++ b/src/main/java/com/example/budongbudong/domain/property/controller/PropertyController.java
@@ -13,6 +13,7 @@ import com.example.budongbudong.domain.property.enums.PropertyType;
 import com.example.budongbudong.domain.property.service.*;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.*;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -23,7 +24,7 @@ import java.util.List;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/properties")
@@ -60,6 +61,9 @@ public class PropertyController {
             @RequestParam(name="status",required = false) AuctionStatus auctionStatus,
             Pageable pageable
     ) {
+        //TODO 전체 기능 구현 완료후 삭제 예정입니다.
+        log.info("alloy loki test log");
+        log.error("alloy loki error test");
         CustomSliceResponse<ReadAllPropertyResponse> response = propertyService.getAllPropertyList(type, auctionStatus, pageable);
         return GlobalResponse.ok(response);
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,3 +100,5 @@ logging:
     org.springframework.data.elasticsearch.client.WIRE: TRACE
     org.springframework.data.elasticsearch: DEBUG
     tracer: TRACE
+  slack:
+    webhook: ${SLACK_WEBHOOK_URL}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,48 @@
+<configuration>
+    <springProperty scope="context"
+                    name="SLACK_WEBHOOK"
+                    source="logging.slack.webhook"/>
+
+    <property name="LOG_DIR" value="./logging/logs"/>
+
+    <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOG_DIR}/application.log</file>
+
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <fileNamePattern>${LOG_DIR}/application.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <maxHistory>7</maxHistory>
+        </rollingPolicy>
+
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"service":"budongbudong","env":"dev"}</customFields>
+        </encoder>
+    </appender>
+
+    <!-- Slack 알림 (ERROR 전용) -->
+    <appender name="SLACK"
+              class="com.github.maricn.logback.SlackAppender">
+
+    <webhookUri>${SLACK_WEBHOOK}</webhookUri>
+    <username>🚨 Error Bot</username>
+    <iconEmoji>:rotating_light:</iconEmoji>
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+        <level>ERROR</level>
+    </filter>
+<layout class="ch.qos.logback.classic.PatternLayout">
+<pattern>🚑 ERROR 발생 확인이 필요합니다
+Service : budongbudong
+Env     : dev
+Time    : %d{yyyy-MM-dd HH:mm:ss}
+
+📍 Error 발생 위치
+%logger{36}
+
+📩 에러 메시지
+%msg</pattern>
+</layout>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="FILE"/>
+        <appender-ref ref="SLACK"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## PR 체크리스트
### 아래 사항을 확인하고 체크해주세요.
- [ ] 코드가 명확하고 읽기 쉬운가
- [ ] 변수 및 함수 이름이 의도를 잘 반영하고 있는가
- [ ] 불필요한 중복 코드는 없는가
- [ ] 클래스에 대한 적절한 주석이나 문서화가 포함되어 있는가
- [ ] 팀 코드 컨벤션 가이드라인을 준수하는가
## 티켓 번호
closed #114

## 작업 사항

- Logback으로 로그 수집
- Loki에 저장
- Grafana를 통해 시각화
    - http://localhost:3000
- Logback으로 수집되는 로그중 ERROR 로그는 개발 편의성을 위해 Slack 알림 기능 추가
- Grafana 대시보드 이미지 첨부
<img width="1908" height="918" alt="스크린샷 2026-02-10 오후 2 01 18" src="https://github.com/user-attachments/assets/4e5e69f4-2502-431b-80aa-a2be2338ca14" />

- 슬랙 알림 이미지 첨부
<img width="382" height="282" alt="스크린샷 2026-02-10 오후 2 32 04" src="https://github.com/user-attachments/assets/500d2d23-d992-4cb8-b6e9-ff3b466a3ae2" />

## 기타 이슈
<!-- 기타 이슈에 대한 내용을 적어주세요 -->
- controller 로그는 추후 채팅, 배치 서버까지 로그 수집하고 삭제하겠습니다