### PR TITLE
[Feat] 매물 등록 전 실거래 정보 결과 미리 보기용 엔드포인트

### DIFF
--- a/src/main/java/com/example/budongbudong/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/budongbudong/common/config/SecurityConfig.java
@@ -13,7 +13,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -144,7 +143,9 @@ public class SecurityConfig {
     private void propertyAuth(
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth
     ) {
-        auth.requestMatchers(HttpMethod.GET, "/api/v1/properties", "/api/v1/properties/*").permitAll()
+        auth.requestMatchers(HttpMethod.POST, "/api/v1/properties/lookup").permitAll()
+
+                .requestMatchers(HttpMethod.GET, "/api/v1/properties", "/api/v1/properties/*").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/v1/properties/my")
                 .hasRole(UserRole.SELLER.name())
 

--- a/src/main/java/com/example/budongbudong/domain/property/controller/PropertyController.java
+++ b/src/main/java/com/example/budongbudong/domain/property/controller/PropertyController.java
@@ -7,8 +7,10 @@ import com.example.budongbudong.domain.auction.enums.AuctionStatus;
 import com.example.budongbudong.domain.property.dto.condition.SearchPropertyCond;
 import com.example.budongbudong.domain.property.dto.request.CreatePropertyRequest;
 import com.example.budongbudong.domain.property.dto.request.PresignedUrlRequest;
+import com.example.budongbudong.domain.property.dto.request.PropertyLookupRequest;
 import com.example.budongbudong.domain.property.dto.request.UpdatePropertyRequest;
 import com.example.budongbudong.domain.property.dto.response.*;
+import com.example.budongbudong.domain.property.dto.response.PropertyLookupResponse;
 import com.example.budongbudong.domain.property.enums.PropertyType;
 import com.example.budongbudong.domain.property.service.*;
 import jakarta.validation.Valid;
@@ -45,6 +47,14 @@ public class PropertyController {
         propertyService.createProperty(request, images, imageUrls, authUser.getUserId());
 
         return GlobalResponse.created(null);
+    }
+
+    @PostMapping("/lookup")
+    public ResponseEntity<GlobalResponse<PropertyLookupResponse>> lookupProperty(
+            @Valid @RequestBody PropertyLookupRequest request
+    ) {
+        PropertyLookupResponse response = propertyService.lookupProperty(request);
+        return GlobalResponse.ok(response);
     }
 
     @PostMapping("/images/presign")

--- a/src/main/java/com/example/budongbudong/domain/property/dto/request/PropertyLookupRequest.java
+++ b/src/main/java/com/example/budongbudong/domain/property/dto/request/PropertyLookupRequest.java
@@ -1,0 +1,20 @@
+package com.example.budongbudong.domain.property.dto.request;
+
+import com.example.budongbudong.domain.property.enums.PropertyType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record PropertyLookupRequest(
+        @NotNull(message = "매물 유형은 필수입니다.")
+        PropertyType type,
+
+        @NotBlank(message = "주소는 필수입니다.")
+        String address,
+
+        @NotBlank(message = "계약연월은 필수입니다.")
+        String dealYmd,
+
+        @NotNull(message = "층수는 필수입니다.")
+        Integer floor
+) {
+}

--- a/src/main/java/com/example/budongbudong/domain/property/dto/response/PropertyLookupResponse.java
+++ b/src/main/java/com/example/budongbudong/domain/property/dto/response/PropertyLookupResponse.java
@@ -1,0 +1,20 @@
+package com.example.budongbudong.domain.property.dto.response;
+
+import java.math.BigDecimal;
+import java.time.Year;
+
+public record PropertyLookupResponse(
+        String name,
+        BigDecimal price,
+        BigDecimal privateArea,
+        Year builtYear
+) {
+    public static PropertyLookupResponse from(CreateApiResponse api) {
+        return new PropertyLookupResponse(
+                api.name(),
+                api.price(),
+                api.privateArea(),
+                api.builtYear()
+        );
+    }
+}


### PR DESCRIPTION
## PR 체크리스트
### 아래 사항을 확인하고 체크해주세요.
- [ ] 코드가 명확하고 읽기 쉬운가
- [ ] 변수 및 함수 이름이 의도를 잘 반영하고 있는가
- [ ] 불필요한 중복 코드는 없는가
- [ ] 클래스에 대한 적절한 주석이나 문서화가 포함되어 있는가
- [ ] 팀 코드 컨벤션 가이드라인을 준수하는가
## 티켓 번호
<!-- 아래에 할당된 티켓 번호를 적어주세요 -->
```java
close #139 
```

## 작업 사항
<!-- 개발에 대한 내용을 적어주세요 -->
<img width="817" height="879" alt="스크린샷 2026-02-12 오후 2 22 50" src="https://github.com/user-attachments/assets/f4d9cda5-8148-44c3-a801-dcd69cd86390" />

- 파란색 부분의 기능에 대한 엔드포인트 입니다
- 실거래 정보 조회 이후 추가 정보 입력시 이전에 어떤 결과가 자동입력 되었는지에 대한 결과를 보여주기 위함
- 클로드가 프론트 구현하며 UX를 위해 매물등록 단계를 분리하는게 좋을것 같다고 추천해줬습니다
## 기타 이슈
